### PR TITLE
Fix null and duplicated class name

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,7 +25,11 @@ function handleStateChangeOnClient(props) {
     if (props.hasOwnProperty(key)) {
       if (key == 'Class' || key == 'class') {
         var currentClasses = document.body.getAttribute(key);
-        document.body.setAttribute(key, currentClasses + ' ' + props[key]);
+        if (!currentClasses) {
+            document.body.setAttribute(key, props[key]);
+        } else if (currentClasses.indexOf(props[key]) === -1)
+            // Simple dedupe to prevent handleStateChangeOnClient() called multiple time
+            document.body.setAttribute(key, currentClasses + ' ' + props[key]);
       } else {
         document.body.setAttribute(key, props[key]);
       }


### PR DESCRIPTION
I found the computed body class is `null aClass aClass aClass`.
The PR has two fixes: 
1. Fix appending `null` if original body does not defined class
2. Fix appending duplicated class name since handleStateChangeOnClient could called multiple times. Proposed a very simple string based dedupe solution, but I think it is good enough for the case.
